### PR TITLE
Add optional parameters to Discovery API calls

### DIFF
--- a/R/clients.R
+++ b/R/clients.R
@@ -14,18 +14,29 @@ set_params <- function(...){
 }
 
 # Get raw data (json format) of selected chart
-charts.get <- function(url = client.url(), did) {
-  req = httr::POST(paste(url, "/api/widgets/", did, "/data", sep=""))
+charts.get <- function(url = client.url(), did, ...) {
+  api_params <- c(...)
+  api_url <- paste(url, "/api/widgets/", did, "/data", sep="")
+
+  req = httr::POST(
+    url = api_url,
+    query = api_params
+  )
   jsonlite::fromJSON(httr::content(req, "text"))
 }
 # Get raw data (json format) of selected dashboard
-dashboards.get <- function(url = client.url(), did) {
-  req = httr::POST(paste(url, "/api/dashboards/", did, "/data", sep=""))
+dashboards.get <- function(url = client.url(), did, ...) {
+  api_params <- c(...)
+  api_url <- paste(url, "/api/dashboards/", did, "/data", sep="")
+
+  req = httr::POST(
+    url = api_url,
+    query = api_params
+  )
   jsonlite::fromJSON(httr::content(req, "text"))
 }
 # Get raw data (json format) of selected datasource
 datasources.get <- function(url = client.url(), did, ...) {
-
   api_params <- c(...)
   api_url <- paste(url, "/api/datasources/", did, "/data", sep="")
 

--- a/R/clients.R
+++ b/R/clients.R
@@ -5,6 +5,14 @@ library(httr)
 client.url <- function(host = "localhost", port = 80) {
   paste("http://", host, ":", port, sep="")
 }
+client.full.url <- function(url = "http://localhost:80") {
+  paste(url)
+}
+
+set_params <- function(...){
+  return(as.list(match.call())[-1])
+}
+
 # Get raw data (json format) of selected chart
 charts.get <- function(url = client.url(), did) {
   req = httr::POST(paste(url, "/api/widgets/", did, "/data", sep=""))
@@ -16,8 +24,15 @@ dashboards.get <- function(url = client.url(), did) {
   jsonlite::fromJSON(httr::content(req, "text"))
 }
 # Get raw data (json format) of selected datasource
-datasources.get <- function(url = client.url(), did) {
-  req = httr::POST(paste(url, "/api/datasources/", did, "/data", sep=""))
+datasources.get <- function(url = client.url(), did, ...) {
+
+  api_params <- c(...)
+  api_url <- paste(url, "/api/datasources/", did, "/data", sep="")
+
+  req = httr::POST(
+    url = api_url,
+    query = api_params
+  )
   jsonlite::fromJSON(httr::content(req, "text"))
 }
 # Print out JSON Object


### PR DESCRIPTION
1. Add `set_params` function for setting optional parameters
2. Add `client.full.url` function for setting full url of Discovery

As a result, you can call a getting datasource API like below :

```R
dataset <- datasources.get(
  client.full.url('${discovery_url}'), 
  '${datasource_id}',
  set_params(limit=10000,intervals='2019-07-01T00:00:00/2019-07-02T00:00:00')
)
```